### PR TITLE
Windows support: some fixes

### DIFF
--- a/dephell_archive/_stream.py
+++ b/dephell_archive/_stream.py
@@ -17,9 +17,9 @@ class ArchiveStream:
     def exists(self) -> bool:
         try:
             if hasattr(self.descriptor, 'getmember'):
-                self.descriptor.getmember(str(self.member_path))  # tar
+                self.descriptor.getmember(self.member_path.as_posix())  # tar
             else:
-                self.descriptor.getinfo(str(self.member_path))  # zip
+                self.descriptor.getinfo(self.member_path.as_posix())  # zip
         except KeyError:
             return False
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+# built-in
+from pathlib import Path
+
+# external
+import pytest
+
+
+@pytest.fixture
+def requirements_path() -> Path:
+    """ Return the absolute Path to 'tests/requirements' """
+    return Path(__file__).parent / Path('requirements')

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from dephell_archive import ArchivePath
 
 
-def test_open_zip(tmpdir):
+def test_open_zip(tmpdir, requirements_path: Path):
     path = ArchivePath(
-        archive_path=Path('tests', 'requirements', 'wheel.whl'),
+        archive_path=requirements_path / 'wheel.whl',
         cache_path=Path(str(tmpdir)),
     )
     subpath = path / 'dephell' / '__init__.py'
@@ -16,9 +16,9 @@ def test_open_zip(tmpdir):
     assert 'from .controllers' in content
 
 
-def test_open_tar_gz(tmpdir):
+def test_open_tar_gz(tmpdir, requirements_path: Path):
     path = ArchivePath(
-        archive_path=Path('tests', 'requirements', 'sdist.tar.gz'),
+        archive_path=requirements_path / 'sdist.tar.gz',
         cache_path=Path(str(tmpdir)),
     )
     subpath = path / 'dephell-0.2.0' / 'setup.py'
@@ -27,9 +27,9 @@ def test_open_tar_gz(tmpdir):
     assert 'from setuptools import' in content
 
 
-def test_glob_zip(tmpdir):
+def test_glob_zip(tmpdir, requirements_path: Path):
     path = ArchivePath(
-        archive_path=Path('tests', 'requirements', 'wheel.whl'),
+        archive_path=requirements_path / 'wheel.whl',
         cache_path=Path(str(tmpdir)),
     )
     paths = list(path.glob('*/__init__.py'))
@@ -37,9 +37,9 @@ def test_glob_zip(tmpdir):
     assert paths[0].as_posix() == 'dephell/__init__.py'
 
 
-def test_glob_tar(tmpdir):
+def test_glob_tar(tmpdir, requirements_path: Path):
     path = ArchivePath(
-        archive_path=Path('tests', 'requirements', 'sdist.tar.gz'),
+        archive_path=requirements_path / 'sdist.tar.gz',
         cache_path=Path(str(tmpdir)),
     )
     paths = list(path.glob('*/setup.py'))
@@ -47,18 +47,18 @@ def test_glob_tar(tmpdir):
     assert paths[0].as_posix() == 'dephell-0.2.0/setup.py'
 
 
-def test_glob_dir(tmpdir):
+def test_glob_dir(tmpdir, requirements_path: Path):
     path = ArchivePath(
-        archive_path=Path('tests', 'requirements', 'sdist.tar.gz'),
+        archive_path=requirements_path / 'sdist.tar.gz',
         cache_path=Path(str(tmpdir)),
     )
     paths = list(path.glob('dephell-*/'))
     assert len(paths) == 1
 
 
-def test_iterdir(tmpdir):
+def test_iterdir(tmpdir, requirements_path: Path):
     path = ArchivePath(
-        archive_path=Path('tests', 'requirements', 'sdist.tar.gz'),
+        archive_path=requirements_path / 'sdist.tar.gz',
         cache_path=Path(str(tmpdir)),
     )
     paths = [str(subpath) for subpath in path.iterdir(recursive=True)]

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -27,6 +27,26 @@ def test_open_tar_gz(tmpdir, requirements_path: Path):
     assert 'from setuptools import' in content
 
 
+def test_exists_zip(tmpdir, requirements_path: Path):
+    path = ArchivePath(
+        archive_path=requirements_path / 'wheel.whl',
+        cache_path=Path(str(tmpdir)),
+    )
+
+    subpath = path / 'dephell' / '__init__.py'
+    assert subpath.exists()
+
+
+def test_exists_tar_gz(tmpdir, requirements_path: Path):
+    path = ArchivePath(
+        archive_path=requirements_path / 'sdist.tar.gz',
+        cache_path=Path(str(tmpdir)),
+    )
+
+    subpath = path / 'dephell-0.2.0' / 'setup.py'
+    assert subpath.exists()
+
+
 def test_glob_zip(tmpdir, requirements_path: Path):
     path = ArchivePath(
         archive_path=requirements_path / 'wheel.whl',


### PR DESCRIPTION
- Fix `tests/requirements` path
- Fix `exists` method in `ArchiveStream` class
- Add tests for `ArchiveStream.exists`

These changes should fix a lot of tests in dephell (see: https://github.com/dephell/dephell/pull/346#issuecomment-567677554)

Related to:
https://github.com/dephell/dephell/pull/346
