### PR TITLE
Handle some obscure cases

### DIFF
--- a/dephell_archive/_path.py
+++ b/dephell_archive/_path.py
@@ -120,6 +120,12 @@ class ArchivePath:
 
     @contextmanager
     def open(self, mode: str = 'r', encoding=None):
+        if 'w' in mode:
+            raise NotImplementedError
+
+        if not self.member_path.name:
+            raise IsADirectoryError
+
         # read from cache
         path = self.cache_path / self.member_path
         if path.exists():
@@ -207,6 +213,9 @@ class ArchivePath:
                 yield path
 
     def exists(self) -> bool:
+        if not self.member_path.name:
+            return True
+
         path = self.cache_path / self.member_path
         if path.exists():
             return True
@@ -214,6 +223,9 @@ class ArchivePath:
             return stream.exists()
 
     def is_file(self) -> bool:
+        if not self.member_path.name:
+            return False
+
         path = self.cache_path / self.member_path
         if path.exists():
             return path.is_file()
@@ -221,6 +233,9 @@ class ArchivePath:
             return stream.is_file()
 
     def is_dir(self) -> bool:
+        if not self.member_path.name:
+            return True
+
         path = self.cache_path / self.member_path
         if path.exists():
             return path.is_dir()

--- a/dephell_archive/_stream.py
+++ b/dephell_archive/_stream.py
@@ -46,6 +46,9 @@ class ArchiveStream:
         return info.filename[-1] == '/'
 
     def read(self):
+        if not self.member_path.name:
+            raise NotImplementedError
+
         path = self.cache_path / self.member_path
         if path.exists():
             raise FileExistsError('file in cache created between open and read')

--- a/tests/test_path_tar.py
+++ b/tests/test_path_tar.py
@@ -1,6 +1,9 @@
 # built-in
 from pathlib import Path
 
+# external
+import pytest
+
 # project
 from dephell_archive import ArchivePath
 
@@ -8,10 +11,64 @@ from dephell_archive import ArchivePath
 sdist_path = Path(__file__).parent / 'requirements' / 'sdist.tar.gz'
 
 
+def test_toplevel(tmpdir):
+    path = ArchivePath(
+        archive_path=sdist_path,
+        cache_path=Path(str(tmpdir)),
+    )
+    assert path.is_dir()
+    assert not path.is_file()
+    assert path.exists()
+
+    with pytest.raises(IsADirectoryError):
+        with path.open():
+            pass
+
+
+def test_toplevel_missing_cache_path(tmpdir):
+    path = ArchivePath(
+        archive_path=sdist_path,
+        cache_path=Path(str(tmpdir), 'missing'),
+    )
+    assert path.is_dir()
+    assert not path.is_file()
+    assert path.exists()
+
+    with pytest.raises(IsADirectoryError):
+        with path.open():
+            pass
+
+    with pytest.raises(NotImplementedError):
+        with path.open('w'):
+            pass
+
+
 def test_open(tmpdir):
     path = ArchivePath(
         archive_path=sdist_path,
         cache_path=Path(str(tmpdir)),
+    )
+    subpath = path / 'dephell-0.2.0' / 'setup.py'
+    with subpath.open() as stream:
+        content = stream.read()
+    assert 'from setuptools import' in content
+
+
+def test_open_write(tmpdir):
+    path = ArchivePath(
+        archive_path=sdist_path,
+        cache_path=Path(str(tmpdir)),
+    )
+    subpath = path / 'dephell-0.2.0'
+    with pytest.raises(NotImplementedError):
+        with subpath.open('w'):
+            pass
+
+
+def test_open_missing_cache_path(tmpdir):
+    path = ArchivePath(
+        archive_path=sdist_path,
+        cache_path=Path(str(tmpdir), 'missing'),
     )
     subpath = path / 'dephell-0.2.0' / 'setup.py'
     with subpath.open() as stream:


### PR DESCRIPTION
When the cache path doesnt exist, top-level path
operations fail.

Also prevent open write mode.

Fixes https://github.com/dephell/dephell_archive/issues/15
Related to https://github.com/dephell/dephell_archive/issues/4